### PR TITLE
Release/weary donkey

### DIFF
--- a/lib/EntityEditorHock.js
+++ b/lib/EntityEditorHock.js
@@ -12,6 +12,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _immutable = require('immutable');
 
 var _WorkflowHock = require('./workflow/WorkflowHock');
@@ -28,6 +32,8 @@ var _Utils = require('./utils/Utils');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -38,20 +44,39 @@ exports.default = function (config) {
     var additionalOperationProps = config.get('operationProps', function () {});
 
     return function (ComposedComponent) {
+        var PureComposedComponent = function (_PureComponent) {
+            _inherits(PureComposedComponent, _PureComponent);
+
+            function PureComposedComponent() {
+                _classCallCheck(this, PureComposedComponent);
+
+                return _possibleConstructorReturn(this, (PureComposedComponent.__proto__ || Object.getPrototypeOf(PureComposedComponent)).apply(this, arguments));
+            }
+
+            _createClass(PureComposedComponent, [{
+                key: 'render',
+                value: function render() {
+                    return _react2.default.createElement(ComposedComponent, this.props);
+                }
+            }]);
+
+            return PureComposedComponent;
+        }(_react.PureComponent);
+
         var EntityEditorHock = function (_Component) {
             _inherits(EntityEditorHock, _Component);
 
             function EntityEditorHock(props) {
                 _classCallCheck(this, EntityEditorHock);
 
-                var _this = _possibleConstructorReturn(this, (EntityEditorHock.__proto__ || Object.getPrototypeOf(EntityEditorHock)).call(this, props));
+                var _this2 = _possibleConstructorReturn(this, (EntityEditorHock.__proto__ || Object.getPrototypeOf(EntityEditorHock)).call(this, props));
 
-                _this.componentIsMounted = false;
-                _this.state = config.get('initialEditorState').toObject();
-                _this.onOperationSuccess = _this.onOperationSuccess.bind(_this);
-                _this.onOperationError = _this.onOperationError.bind(_this);
-                _this.setEditorState = _this.setEditorState.bind(_this);
-                return _this;
+                _this2.componentIsMounted = false;
+                _this2.state = config.get('initialEditorState').toObject();
+                _this2.onOperationSuccess = _this2.onOperationSuccess.bind(_this2);
+                _this2.onOperationError = _this2.onOperationError.bind(_this2);
+                _this2.setEditorState = _this2.setEditorState.bind(_this2);
+                return _this2;
             }
 
             /*
@@ -147,7 +172,7 @@ exports.default = function (config) {
             }, {
                 key: 'partiallyApplyOperations',
                 value: function partiallyApplyOperations(operations, props) {
-                    var _this2 = this;
+                    var _this3 = this;
 
                     // TOD MEMOIZE THIS ON PROP CHANGE
 
@@ -168,7 +193,7 @@ exports.default = function (config) {
                         // create operationsProps object to be passed into the first operation function
                         var operationProps = (0, _immutable.Map)(_extends({}, additional, {
                             operations: mutableOperations,
-                            setEditorState: _this2.setEditorState
+                            setEditorState: _this3.setEditorState
                         })).filter(function (ii) {
                             return ii;
                         }).toObject();
@@ -192,31 +217,31 @@ exports.default = function (config) {
             }, {
                 key: 'onOperationSuccess',
                 value: function onOperationSuccess(_ref, nextWorkflow) {
-                    var _this3 = this;
-
-                    var onSuccess = _ref.onSuccess;
-
-                    return function (result) {
-                        if (!_this3.componentIsMounted || _this3.props.workflow.name != nextWorkflow.name) {
-                            return;
-                        }
-                        onSuccess && onSuccess(result);
-                        _this3.props.workflow.next("onSuccess", _this3.props.workflow.end);
-                    };
-                }
-            }, {
-                key: 'onOperationError',
-                value: function onOperationError(_ref2, nextWorkflow) {
                     var _this4 = this;
 
-                    var onError = _ref2.onError;
+                    var onSuccess = _ref.onSuccess;
 
                     return function (result) {
                         if (!_this4.componentIsMounted || _this4.props.workflow.name != nextWorkflow.name) {
                             return;
                         }
+                        onSuccess && onSuccess(result);
+                        _this4.props.workflow.next("onSuccess", _this4.props.workflow.end);
+                    };
+                }
+            }, {
+                key: 'onOperationError',
+                value: function onOperationError(_ref2, nextWorkflow) {
+                    var _this5 = this;
+
+                    var onError = _ref2.onError;
+
+                    return function (result) {
+                        if (!_this5.componentIsMounted || _this5.props.workflow.name != nextWorkflow.name) {
+                            return;
+                        }
                         onError && onError(result);
-                        _this4.props.workflow.next("onError", _this4.props.workflow.end);
+                        _this5.props.workflow.next("onError", _this5.props.workflow.end);
                     };
                 }
 
@@ -272,13 +297,13 @@ exports.default = function (config) {
             }, {
                 key: 'entityEditorProps',
                 value: function entityEditorProps(statusProps) {
-                    var _this5 = this;
+                    var _this6 = this;
 
                     // actions
 
                     var actions = config.get('actions', (0, _immutable.Map)()).map(function (actionConfig, actionName) {
                         return function (actionProps) {
-                            _this5.workflowStart(actionName, actionConfig, actionProps);
+                            _this6.workflowStart(actionName, actionConfig, actionProps);
                         };
                     }).toObject();
 
@@ -327,16 +352,24 @@ exports.default = function (config) {
             }, {
                 key: 'render',
                 value: function render() {
-                    var workflow = this.props.workflow;
+                    var _props = this.props,
+                        workflow = _props.workflow,
+                        passConfig = _props.passConfig,
+                        filteredProps = _objectWithoutProperties(_props, ['workflow', 'passConfig']);
 
+                    var editorState = this.getEditorState();
                     var statusProps = _extends({
-                        editorState: this.getEditorState()
+                        editorState: editorState
                     }, config.itemNames());
+
+                    if (passConfig) {
+                        filteredProps.config = config;
+                    }
 
                     return _react2.default.createElement(
                         'div',
                         null,
-                        _react2.default.createElement(ComposedComponent, _extends({}, this.props, {
+                        _react2.default.createElement(PureComposedComponent, _extends({}, filteredProps, {
                             entityEditor: this.entityEditorProps(statusProps)
                         })),
                         _react2.default.createElement(_PromptContainer2.default, {
@@ -351,6 +384,11 @@ exports.default = function (config) {
 
             return EntityEditorHock;
         }(_react.Component);
+
+        EntityEditorHock.propTypes = {
+            workflow: _propTypes2.default.object.isRequired,
+            passConfig: _propTypes2.default.bool
+        };
 
         var withWorkflowHock = (0, _WorkflowHock2.default)();
         return withWorkflowHock(EntityEditorHock);

--- a/lib/config/BaseConfig.js
+++ b/lib/config/BaseConfig.js
@@ -29,10 +29,10 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
         single: "item"
     },
     actions: {
-        save: {
-            description: "If the item already exists this calls the update operation, or calls create for new items.",
+        create: {
+            description: "Calls the create operation.",
             workflow: {
-                task: "saveOperate",
+                task: "createOperate",
                 next: {
                     onSuccess: {
                         task: "saveSuccess"
@@ -43,19 +43,16 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
                 }
             }
         },
-        saveNew: {
-            description: "Always calls create to make a new item, regardless of whether the data was loaded from an existing item.",
+        update: {
+            description: "Calls the update operation.",
             workflow: {
-                task: "saveNewConfirm",
-                onYes: {
-                    task: "saveNewOperate",
-                    next: {
-                        onSuccess: {
-                            task: "saveNewSuccess"
-                        },
-                        onError: {
-                            task: "saveError"
-                        }
+                task: "updateOperate",
+                next: {
+                    onSuccess: {
+                        task: "saveSuccess"
+                    },
+                    onError: {
+                        task: "saveError"
                     }
                 }
             }
@@ -79,6 +76,37 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
                 }
             }
         },
+        save: {
+            description: "If the item already exists this calls the update operation, or calls create for new items.",
+            workflow: {
+                task: "saveOperate",
+                next: {
+                    onSuccess: {
+                        task: "saveSuccess"
+                    },
+                    onError: {
+                        task: "saveError"
+                    }
+                }
+            }
+        },
+        saveNew: {
+            description: "Always calls create to make a new item, regardless of whether the data was loaded from an existing item.",
+            workflow: {
+                task: "saveNewConfirm",
+                onYes: {
+                    task: "createOperate",
+                    next: {
+                        onSuccess: {
+                            task: "saveNewSuccess"
+                        },
+                        onError: {
+                            task: "saveError"
+                        }
+                    }
+                }
+            }
+        },
         go: {
             description: "Navigates to another route or view",
             workflow: {
@@ -92,17 +120,12 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
         }
     },
     tasks: {
-        saveOperate: {
+        createOperate: {
             operate: function operate(_ref) {
                 var operations = _ref.operations;
                 return function (actionProps) {
                     if (!actionProps.payload) {
-                        throw 'EntityEditor: config.actions.save: actionProps.payload is not defined';
-                    }
-                    if (actionProps.id) {
-                        return operations.update(actionProps).then(function () {
-                            return operations.dirty({ dirty: false });
-                        });
+                        throw 'EntityEditor: config.actions.create: actionProps.payload is not defined';
                     }
                     return operations.create(actionProps).then(function () {
                         return operations.dirty({ dirty: false });
@@ -124,9 +147,68 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             },
             statusOutput: "prompt"
         },
+        updateOperate: {
+            operate: function operate(_ref3) {
+                var operations = _ref3.operations;
+                return function (actionProps) {
+                    if (!actionProps.payload) {
+                        throw 'EntityEditor: config.actions.update: actionProps.payload is not defined';
+                    }
+                    return operations.update(actionProps).then(function () {
+                        return operations.dirty({ dirty: false });
+                    });
+                };
+            },
+            status: function status(_ref4) {
+                var item = _ref4.item;
+                return {
+                    title: "Saving",
+                    message: _react2.default.createElement(
+                        'span',
+                        null,
+                        'Saving ',
+                        item,
+                        '...'
+                    )
+                };
+            },
+            statusOutput: "prompt"
+        },
+        saveOperate: {
+            operate: function operate(_ref5) {
+                var operations = _ref5.operations;
+                return function (actionProps) {
+                    if (!actionProps.payload) {
+                        throw 'EntityEditor: config.actions.save: actionProps.payload is not defined';
+                    }
+                    if (actionProps.id) {
+                        return operations.update(actionProps).then(function () {
+                            return operations.dirty({ dirty: false });
+                        });
+                    }
+                    return operations.create(actionProps).then(function () {
+                        return operations.dirty({ dirty: false });
+                    });
+                };
+            },
+            status: function status(_ref6) {
+                var item = _ref6.item;
+                return {
+                    title: "Saving",
+                    message: _react2.default.createElement(
+                        'span',
+                        null,
+                        'Saving ',
+                        item,
+                        '...'
+                    )
+                };
+            },
+            statusOutput: "prompt"
+        },
         saveSuccess: {
-            status: function status(_ref3) {
-                var Item = _ref3.Item;
+            status: function status(_ref7) {
+                var Item = _ref7.Item;
                 return {
                     title: "Saved",
                     message: _react2.default.createElement(
@@ -141,8 +223,8 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             statusOutput: "prompt"
         },
         saveError: {
-            status: function status(_ref4) {
-                var item = _ref4.item;
+            status: function status(_ref8) {
+                var item = _ref8.item;
                 return {
                     title: "Error",
                     message: _react2.default.createElement(
@@ -158,8 +240,8 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             statusOutput: "prompt"
         },
         saveNewConfirm: {
-            status: function status(_ref5) {
-                var item = _ref5.item;
+            status: function status(_ref9) {
+                var item = _ref9.item;
                 return {
                     title: "Confirm",
                     message: _react2.default.createElement(
@@ -175,36 +257,9 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             },
             statusOutput: "prompt"
         },
-        saveNewOperate: {
-            operate: function operate(_ref6) {
-                var operations = _ref6.operations;
-                return function (actionProps) {
-                    if (!actionProps.payload) {
-                        throw 'EntityEditor: config.actions.saveNew: actionProps.payload is not defined';
-                    }
-                    return operations.create(actionProps).then(function () {
-                        return operations.dirty({ dirty: false });
-                    });
-                };
-            },
-            status: function status(_ref7) {
-                var item = _ref7.item;
-                return {
-                    title: "Saving",
-                    message: _react2.default.createElement(
-                        'span',
-                        null,
-                        'Saving ',
-                        item,
-                        '...'
-                    )
-                };
-            },
-            statusOutput: "prompt"
-        },
         saveNewSuccess: {
-            status: function status(_ref8) {
-                var item = _ref8.item;
+            status: function status(_ref10) {
+                var item = _ref10.item;
                 return {
                     title: "Saved",
                     message: _react2.default.createElement(
@@ -220,8 +275,8 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             statusOutput: "prompt"
         },
         deleteConfirm: {
-            status: function status(_ref9) {
-                var item = _ref9.item;
+            status: function status(_ref11) {
+                var item = _ref11.item;
                 return {
                     title: "Confirm",
                     message: _react2.default.createElement(
@@ -238,8 +293,8 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             statusOutput: "prompt"
         },
         deleteOperate: {
-            operate: function operate(_ref10) {
-                var operations = _ref10.operations;
+            operate: function operate(_ref12) {
+                var operations = _ref12.operations;
                 return function (actionProps) {
                     if (!actionProps.id) {
                         throw 'EntityEditor: config.actions.delete: actionProps.id is not defined';
@@ -249,8 +304,8 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
                     });
                 };
             },
-            status: function status(_ref11) {
-                var item = _ref11.item;
+            status: function status(_ref13) {
+                var item = _ref13.item;
                 return {
                     title: "Deleting",
                     message: _react2.default.createElement(
@@ -265,8 +320,8 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             statusOutput: "prompt"
         },
         deleteSuccess: {
-            status: function status(_ref12) {
-                var Item = _ref12.Item;
+            status: function status(_ref14) {
+                var Item = _ref14.Item;
                 return {
                     title: "Deleted",
                     message: _react2.default.createElement(
@@ -281,8 +336,8 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             statusOutput: "prompt"
         },
         deleteError: {
-            status: function status(_ref13) {
-                var item = _ref13.item;
+            status: function status(_ref15) {
+                var item = _ref15.item;
                 return {
                     title: "Error",
                     message: _react2.default.createElement(
@@ -298,8 +353,8 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             statusOutput: "prompt"
         },
         goConfirm: {
-            skip: function skip(_ref14) {
-                var editorState = _ref14.editorState;
+            skip: function skip(_ref16) {
+                var editorState = _ref16.editorState;
                 return editorState.dirty ? null : "onYes";
             },
             status: function status() {
@@ -317,8 +372,8 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
             statusOutput: "prompt"
         },
         goOperate: {
-            operate: function operate(_ref15) {
-                var operations = _ref15.operations;
+            operate: function operate(_ref17) {
+                var operations = _ref17.operations;
                 return function (actionProps) {
                     return operations.go(actionProps);
                 };
@@ -326,10 +381,30 @@ var BaseConfig = (0, _EntityEditorConfig2.default)({
         }
     },
     operations: {
-        dirty: function dirty(_ref16) {
-            var setEditorState = _ref16.setEditorState;
-            return function (_ref17) {
-                var dirty = _ref17.dirty;
+        create: function create() {
+            return function () {
+                console.warn('"create" operation not defined');
+            };
+        },
+        update: function update() {
+            return function () {
+                console.warn('"update" operation not defined');
+            };
+        },
+        delete: function _delete() {
+            return function () {
+                console.warn('"delete" operation not defined');
+            };
+        },
+        go: function go() {
+            return function () {
+                console.warn('"go" operation not defined');
+            };
+        },
+        dirty: function dirty(_ref18) {
+            var setEditorState = _ref18.setEditorState;
+            return function (_ref19) {
+                var dirty = _ref19.dirty;
 
                 setEditorState({ dirty: dirty });
             };

--- a/lib/config/EntityEditorConfig.js
+++ b/lib/config/EntityEditorConfig.js
@@ -44,7 +44,14 @@ var EntityEditorConfig = function () {
             var toMerge = EntityEditorConfig.isEntityEditorConfig(nextConfig) ? nextConfig._config : (0, _immutable.fromJS)(nextConfig);
 
             // merge configs together
-            var merged = this._config.mergeDeep(toMerge).toJS();
+            // only merge Maps, and not workflow
+            var mergeFunction = function mergeFunction(oldVal, newVal, key) {
+                var doMerge = _immutable.Map.isMap(oldVal) && _immutable.Map.isMap(newVal) && key != "workflow";
+
+                return doMerge ? oldVal.mergeWith(mergeFunction, newVal) : newVal;
+            };
+
+            var merged = this._config.mergeWith(mergeFunction, toMerge).toJS();
 
             return new EntityEditorConfig(merged);
         }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "test": "NODE_ENV=test nyc --report-dir=./coverage ava && yarn run check-coverage",
     "test-all": "NODE_ENV=test yarn run lint && yarn run flow && yarn run test"
   },
+  "peerDependencies": {
+    "react": "^15.3.2"
+  },
   "devDependencies": {
     "ava": "0.19.1",
     "babel-cli": "^6.23.0",

--- a/src/EntityEditorHock.jsx
+++ b/src/EntityEditorHock.jsx
@@ -269,15 +269,25 @@ export default (config: EntityEditorConfig): Function => {
              */
 
             render(): React.Element<any> {
-                const {workflow} = this.props;
+                var {
+                    workflow,
+                    passConfig,
+                    ...filteredProps
+                } = this.props;
+
+                const editorState: Object = this.getEditorState();
                 const statusProps: Object = {
-                    editorState: this.getEditorState(),
+                    editorState,
                     ...config.itemNames()
                 };
 
+                if(passConfig) {
+                    filteredProps.config = config;
+                }
+
                 return <div>
-                    <ComposedComponent
-                        {...this.props}
+                    <PureComposedComponent
+                        {...filteredProps}
                         entityEditor={this.entityEditorProps(statusProps)}
                     />
                     <PromptContainer

--- a/src/EntityEditorHock.jsx
+++ b/src/EntityEditorHock.jsx
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, {Component} from 'react';
+import React, {Component, PureComponent} from 'react';
+import PropTypes from 'prop-types';
 import {Map} from 'immutable';
 import WorkflowHock from './workflow/WorkflowHock';
 import PromptContainer from './prompt/PromptContainer';
@@ -11,6 +12,12 @@ export default (config: EntityEditorConfig): Function => {
     const additionalOperationProps: Function = config.get('operationProps', () => {});
 
     return (ComposedComponent: ReactClass<any>): ReactClass<any> => {
+
+        class PureComposedComponent extends PureComponent {
+            render() {
+                return <ComposedComponent {...this.props} />;
+            }
+        }
 
         class EntityEditorHock extends Component {
 
@@ -299,6 +306,11 @@ export default (config: EntityEditorConfig): Function => {
                 </div>;
             }
         }
+
+        EntityEditorHock.propTypes = {
+            workflow: PropTypes.object.isRequired,
+            passConfig: PropTypes.bool
+        };
 
         const withWorkflowHock: Function = WorkflowHock();
         return withWorkflowHock(EntityEditorHock);

--- a/src/config/BaseConfig.jsx
+++ b/src/config/BaseConfig.jsx
@@ -14,10 +14,10 @@ const BaseConfig: EntityEditorConfig = EntityEditorConfig({
         single: "item"
     },
     actions: {
-        save: {
-            description: "If the item already exists this calls the update operation, or calls create for new items.",
+        create: {
+            description: "Calls the create operation.",
             workflow: {
-                task: "saveOperate",
+                task: "createOperate",
                 next: {
                     onSuccess: {
                         task: "saveSuccess"
@@ -28,19 +28,16 @@ const BaseConfig: EntityEditorConfig = EntityEditorConfig({
                 }
             }
         },
-        saveNew: {
-            description: "Always calls create to make a new item, regardless of whether the data was loaded from an existing item.",
+        update: {
+            description: "Calls the update operation.",
             workflow: {
-                task: "saveNewConfirm",
-                onYes: {
-                    task: "saveNewOperate",
-                    next: {
-                        onSuccess: {
-                            task: "saveNewSuccess"
-                        },
-                        onError: {
-                            task: "saveError"
-                        }
+                task: "updateOperate",
+                next: {
+                    onSuccess: {
+                        task: "saveSuccess"
+                    },
+                    onError: {
+                        task: "saveError"
                     }
                 }
             }
@@ -64,6 +61,37 @@ const BaseConfig: EntityEditorConfig = EntityEditorConfig({
                 }
             }
         },
+        save: {
+            description: "If the item already exists this calls the update operation, or calls create for new items.",
+            workflow: {
+                task: "saveOperate",
+                next: {
+                    onSuccess: {
+                        task: "saveSuccess"
+                    },
+                    onError: {
+                        task: "saveError"
+                    }
+                }
+            }
+        },
+        saveNew: {
+            description: "Always calls create to make a new item, regardless of whether the data was loaded from an existing item.",
+            workflow: {
+                task: "saveNewConfirm",
+                onYes: {
+                    task: "createOperate",
+                    next: {
+                        onSuccess: {
+                            task: "saveNewSuccess"
+                        },
+                        onError: {
+                            task: "saveError"
+                        }
+                    }
+                }
+            }
+        },
         go: {
             description: "Navigates to another route or view",
             workflow: {
@@ -77,6 +105,36 @@ const BaseConfig: EntityEditorConfig = EntityEditorConfig({
         }
     },
     tasks: {
+        createOperate: {
+            operate: ({operations}) => (actionProps: {id: ?string, payload: Object}): Promiseable => {
+                if(!actionProps.payload) {
+                    throw `EntityEditor: config.actions.create: actionProps.payload is not defined`;
+                }
+                return operations
+                    .create(actionProps)
+                    .then(() => operations.dirty({dirty: false}));
+            },
+            status: ({item}) => ({
+                title: "Saving",
+                message: <span>Saving {item}...</span>
+            }),
+            statusOutput: "prompt"
+        },
+        updateOperate: {
+            operate: ({operations}) => (actionProps: {id: ?string, payload: Object}): Promiseable => {
+                if(!actionProps.payload) {
+                    throw `EntityEditor: config.actions.update: actionProps.payload is not defined`;
+                }
+                return operations
+                    .update(actionProps)
+                    .then(() => operations.dirty({dirty: false}));
+            },
+            status: ({item}) => ({
+                title: "Saving",
+                message: <span>Saving {item}...</span>
+            }),
+            statusOutput: "prompt"
+        },
         saveOperate: {
             operate: ({operations}) => (actionProps: {id: ?string, payload: Object}): Promiseable => {
                 if(!actionProps.payload) {
@@ -119,21 +177,6 @@ const BaseConfig: EntityEditorConfig = EntityEditorConfig({
                 message: <span>Are you sure you want to save this as a new {item}?</span>,
                 yes: `Save as new`,
                 no: `Cancel`
-            }),
-            statusOutput: "prompt"
-        },
-        saveNewOperate: {
-            operate: ({operations}) => (actionProps: {id: ?string, payload: Object}): Promiseable => {
-                if(!actionProps.payload) {
-                    throw `EntityEditor: config.actions.saveNew: actionProps.payload is not defined`;
-                }
-                return operations
-                    .create(actionProps)
-                    .then(() => operations.dirty({dirty: false}));
-            },
-            status: ({item}) => ({
-                title: "Saving",
-                message: <span>Saving {item}...</span>
             }),
             statusOutput: "prompt"
         },
@@ -203,6 +246,18 @@ const BaseConfig: EntityEditorConfig = EntityEditorConfig({
         }
     },
     operations: {
+        create: () => (): Promiseable => {
+            console.warn(`"create" operation not defined`);
+        },
+        update: () => (): Promiseable => {
+            console.warn(`"update" operation not defined`);
+        },
+        delete: () => (): Promiseable => {
+            console.warn(`"delete" operation not defined`);
+        },
+        go: () => (): Promiseable => {
+            console.warn(`"go" operation not defined`);
+        },
         dirty: ({setEditorState}) => ({dirty}: {dirty: boolean}): Promiseable => {
             setEditorState({dirty});
         }

--- a/src/config/EntityEditorConfig.js
+++ b/src/config/EntityEditorConfig.js
@@ -41,8 +41,17 @@ class EntityEditorConfig {
             : fromJS(nextConfig);
 
         // merge configs together
+        // only merge Maps, and not workflow
+        const mergeFunction: Function = (oldVal: *, newVal: *, key: *): * => {
+            const doMerge: boolean = Map.isMap(oldVal)
+                && Map.isMap(newVal)
+                && key != "workflow";
+
+            return doMerge ? oldVal.mergeWith(mergeFunction, newVal) : newVal;
+        };
+
         const merged: Object = this._config
-            .mergeDeep(toMerge)
+            .mergeWith(mergeFunction, toMerge)
             .toJS();
 
         return new EntityEditorConfig(merged);


### PR DESCRIPTION
- Composed components inside of `EntityEditorHock` are now pure render.
- Added stub operations to `BaseConfig` to warn if you haven't set them yourself.
- Added create and update actions and matching operations to `BaseConfig`.
- Bug fix: merging configs no longer merges arrays or workflows.
- `EntityEditorHock` no longer passes `workflow` prop.
- Can now pass `passConfig` prop to `EntityEditorHock` to force it to pass down its config. Intended for use by other higher order components.